### PR TITLE
Modify the escape parameter behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Remove the abstract declaration of `Ajgl\Csv\Rfc\CsvRfcUtils`
 - Declare the `Ajgl\Csv\Rfc\CsvRfcUtils` constructor as private
+- In writing context, the escape char should be a backslash (`\`), any other value will be ignored.
 
 ## 0.1.0 - 2016-02-25
 ### Added

--- a/src/CsvRfcUtils.php
+++ b/src/CsvRfcUtils.php
@@ -35,9 +35,9 @@ class CsvRfcUtils
      * @param string   $escape
      * @param string   $eol
      */
-    public static function fPutCsv($handle, array $fields, $delimiter = ',', $enclosure = '"', $escape = '"', $eol = null)
+    public static function fPutCsv($handle, array $fields, $delimiter = ',', $enclosure = '"', $escape = '\\', $eol = null)
     {
-        self::checkCsvEscape($enclosure, $escape);
+        self::checkPutCsvEscape($escape);
 
         $eol = self::resolveEol($eol);
         if ($eol !== self::EOL_WRITE_DEFAULT || self::hasAnyValueWithEscapeFollowedByEnclosure($fields, $enclosure)) {
@@ -87,7 +87,7 @@ class CsvRfcUtils
      */
     public static function fGetCsv($handle, $length = 0, $delimiter = ',', $enclosure = '"', $escape = '"')
     {
-        self::checkCsvEscape($enclosure, $escape);
+        self::checkGetCsvEscape($enclosure, $escape);
 
         return \fgetcsv($handle, $length, $delimiter, $enclosure, $enclosure);
     }
@@ -104,7 +104,7 @@ class CsvRfcUtils
      */
     public static function strGetCsv($input, $delimiter = ',', $enclosure = '"', $escape = '"')
     {
-        self::checkCsvEscape($enclosure, $escape);
+        self::checkGetCsvEscape($enclosure, $escape);
 
         return \str_getcsv($input, $delimiter, $enclosure, $enclosure);
     }
@@ -156,17 +156,37 @@ class CsvRfcUtils
     }
 
     /**
+     * Emits a warning if the escape char is not the default backslash or null.
+     *
+     * @param string $escape
+     */
+    public static function checkPutCsvEscape($escape)
+    {
+        if ($escape !== '\\' && $escape !== null) {
+            trigger_error(
+                sprintf(
+                    "In writing mode, the escape char must be a backslash '\\'. "
+                        ."The given escape char '%s' will be ignored.",
+                    $escape
+                ),
+                E_USER_WARNING
+            );
+        }
+    }
+
+    /**
      * Emits a warning if the enclosure char and escape char are different.
      *
      * @param string $enclosure
      * @param string $escape
      */
-    public static function checkCsvEscape($enclosure, $escape)
+    public static function checkGetCsvEscape($enclosure, $escape)
     {
         if ($enclosure !== $escape) {
             trigger_error(
                 sprintf(
-                    "The escape and enclosure chars must be equals. The given escape char '%s' will be ignored.",
+                    'In reading mode, the escape and enclosure chars must be equals. '
+                        ."The given escape char '%s' will be ignored.",
                     $escape
                 ),
                 E_USER_WARNING

--- a/src/Spl/SplFileObjectTrait.php
+++ b/src/Spl/SplFileObjectTrait.php
@@ -28,31 +28,22 @@ trait SplFileObjectTrait
         $this->setCsvControl($delimiter, $enclosure);
     }
 
-    /**
-     * @param string $enclosure
-     * @param string $escape
-     */
-    protected function checkEscapeChar($enclosure, $escape)
-    {
-        CsvRfcUtils::checkCsvEscape($enclosure, $escape);
-    }
-
     public function fgetcsv($delimiter = ',', $enclosure = '"', $escape = '"')
     {
-        $this->checkEscapeChar($enclosure, $escape);
+        CsvRfcUtils::checkGetCsvEscape($enclosure, $escape);
 
         return parent::fgetcsv($delimiter, $enclosure, $enclosure);
     }
 
-    public function fputcsv($fields, $delimiter = ',', $enclosure = '"', $escape = '"')
+    public function fputcsv($fields, $delimiter = ',', $enclosure = '"', $escape = '\\')
     {
-        $this->checkEscapeChar($enclosure, $escape);
+        CsvRfcUtils::checkPutCsvEscape($escape);
         $this->fwrite(CsvRfcUtils::strPutCsv($fields, $delimiter, $enclosure));
     }
 
     public function setCsvControl($delimiter = ',', $enclosure = '"', $escape = '"')
     {
-        $this->checkEscapeChar($enclosure, $escape);
+        CsvRfcUtils::checkGetCsvEscape($enclosure, $escape);
         parent::setCsvControl($delimiter, $enclosure, $enclosure);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -20,7 +20,7 @@ namespace Ajgl\Csv\Rfc;
  * @param string   $enclosure
  * @param string   $escape
  */
-function fputcsv($handle, array $fields, $delimiter = ',', $enclosure = '"', $escape = '"')
+function fputcsv($handle, array $fields, $delimiter = ',', $enclosure = '"', $escape = '\\')
 {
     CsvRfcUtils::fPutCsv($handle, $fields, $delimiter, $enclosure, $escape);
 }

--- a/tests/CsvRfcUtilsTest.php
+++ b/tests/CsvRfcUtilsTest.php
@@ -107,7 +107,7 @@ class CsvRfcUtilsTest extends \PHPUnit_Framework_TestCase
         );
 
         $fp = fopen('php://temp', 'w+');
-        CsvRfcUtils::fPutCsv($fp, $fields, ';', "'", "'");
+        CsvRfcUtils::fPutCsv($fp, $fields, ';', "'");
         rewind($fp);
         $this->assertEquals(
             "Hello,World!;'Hello;World!';'Hello\\\"World\\\"!';'Hello\''World\''!';'Hello\nWorld!'\n",
@@ -115,7 +115,7 @@ class CsvRfcUtilsTest extends \PHPUnit_Framework_TestCase
         );
 
         $fp = fopen('php://temp', 'w+');
-        CsvRfcUtils::fPutCsv($fp, $fields, ';', "'", "'", CsvRfcUtils::EOL_WRITE_RFC);
+        CsvRfcUtils::fPutCsv($fp, $fields, ';', "'", null, CsvRfcUtils::EOL_WRITE_RFC);
         rewind($fp);
         $this->assertEquals(
             "Hello,World!;'Hello;World!';'Hello\\\"World\\\"!';'Hello\''World\''!';'Hello\nWorld!'\r\n",
@@ -155,7 +155,7 @@ class CsvRfcUtilsTest extends \PHPUnit_Framework_TestCase
         );
 
         $fp = fopen('php://temp', 'w+');
-        CsvRfcUtils::fPutCsv($fp, $fields, ';', "'", "'");
+        CsvRfcUtils::fPutCsv($fp, $fields, ';', "'");
         rewind($fp);
         $this->assertEquals(
             "Hello,World!;'Hello;World!';'Hello\\\"World\\\"!';'Hello\''World\''!';'Hello\nWorld!'\r\n",

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -86,7 +86,7 @@ class functionsTest extends \PHPUnit_Framework_TestCase
         );
 
         $fp = fopen('php://temp', 'w+');
-        Rfc\fputcsv($fp, $fields, ';', "'", "'");
+        Rfc\fputcsv($fp, $fields, ';', "'");
         rewind($fp);
         $this->assertEquals(
             "Hello,World!;'Hello;World!';'Hello\\\"World\\\"!';'Hello\''World\''!';'Hello\nWorld!'\n",


### PR DESCRIPTION
The escape char must be a backslash (`\`) in writing context, and equals to the enclosure char in reading context.
