### PR TITLE
Support for PHP 7.1, 7.2, 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,17 @@ matrix:
         - php: 5.5
         - php: 5.6
         - php: 7
+        - php: 7.1
+        - php: 7.2
+        - php: 7.3
     allow_failures:
         - php: hhvm
     fast_finish: true
 
 before_script:
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
-script: phpunit --coverage-clover=coverage.clover
+script:
+  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.7",
         "fabpot/php-cs-fixer": "^1.11",
-        "league/csv": ">=7.2"
+        "league/csv": ">=7.2,<9.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
- Update "Travis CI" configuration
- Update required version of `league/csv`, `phpunit/phpunit`

`CsvRfcWriteStreamFilterTest` depends method `appendStreamFilter`, but in v9 it is removed.
ref. https://github.com/thephpleague/csv/blob/master/CHANGELOG.md